### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/File/Spec/Case.pm
+++ b/lib/File/Spec/Case.pm
@@ -1,4 +1,4 @@
-class File::Spec::Case;
+unit class File::Spec::Case;
 
 method default-case-tolerant ($OS = $*OS) {
     so $OS eq any <MacOS Mac VMS darwin Win32 MSWin32 os2 dos NetWare symbian cygwin Cygwin epoc>;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
