### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
   "perl"        : "6.*",
   "name"        : "File::Spec::Case",
+  "license"     : "Artistic-2.0",
   "version"     : "*",
   "description" : "Check if your filesystem is case sensitive or case tolerant (insensitive)",
   "author"      : "labster",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license